### PR TITLE
feat:suppot infer slice tensor at dim > 0 and optimize memory

### DIFF
--- a/awex/converter/sglang_converter.py
+++ b/awex/converter/sglang_converter.py
@@ -70,17 +70,12 @@ class SGlangToHFWeightConverter:
     def _use_transposed_moe_layout(self, name: str, parameter: torch.Tensor) -> bool:
         if self.device_backend != "npu" or parameter.ndim != 2:
             return False
-        # vLLM-ascend fused MoE kernels keep expert MLP weights in transposed layout.
-        return "experts" in name or "shared_experts" in name
+        # vLLM-ascend only transposes normal experts
+        return "experts" in name and "shared_experts" not in name
 
     def _split_gate_up(
         self, name: str, parameter: torch.Tensor
     ) -> List[Tuple[str, torch.Tensor]]:
-        if self._use_transposed_moe_layout(name, parameter):
-            # vLLM-ascend stores MoE fc1 in transposed layout [H, 2I].
-            # Build canonical views [2I, H] first so transfer/meta remain in
-            # canonical HF/Megatron orientation.
-            parameter = parameter.transpose(0, 1)
         split_dim = 0
         shape_split = parameter.shape[split_dim]
         stride = shape_split // 2
@@ -162,35 +157,28 @@ class SGlangToHFWeightConverter:
             mlp.down_proj.weight
             mlp.w13_weight
             mlp.w2_weight
+            mlp.shared_experts.gate_up_proj.weight
+            mlp.shared_experts.down_proj.weight
         Return example:
             mlp.gate_up_proj.weight
             mlp.down_proj.weight
         """
+        if self._use_transposed_moe_layout(name, parameter):
+            parameter = parameter.transpose(0, 1)
         if "gate_up_proj" in name:
             if self._fuse_gate_up_proj(name):
                 # Keep fused format
                 return [(name, parameter)]
             else:
-                # Split into separate gate and up projections.
-                # On vLLM-ascend MoE, gate_up tensors are transposed and must be split on dim=1.
                 return self._split_gate_up(name, parameter)
         elif "down_proj" in name:
-            if self._use_transposed_moe_layout(name, parameter):
-                # vLLM-ascend stores MoE fc2 in transposed layout [I, H].
-                # Expose canonical view [H, I].
-                parameter = parameter.transpose(0, 1)
             return [(name, parameter)]
         elif "w13_weight" in name:
-            # Handle MoE expert weights (w13_weight contains both gate and up projections)
             if self._fuse_gate_up_proj(name):
                 return [(name.replace("w13_weight", "gate_up_proj.weight"), parameter)]
             else:
-                # On vLLM-ascend MoE, w13 tensors are transposed and must be split on dim=1.
                 return self._split_gate_up(name, parameter)
         elif "w2_weight" in name:
-            # Handle MoE expert down projection
-            if self._use_transposed_moe_layout(name, parameter):
-                parameter = parameter.transpose(0, 1)
             return [(name.replace("w2_weight", "down_proj.weight"), parameter)]
         else:
             raise NotImplementedError(f"Unsupported MLP parameter name: {name}")
@@ -253,6 +241,9 @@ class SGlangToHFWeightConverter:
         # w2_weight shape: num_experts_per_partition, hidden_size, intermediate_size
         if "expert_bias" in name:
             return [(name, parameter)]
+        if "shared_experts" in name:
+            # shared_experts not fused with normal experts
+            return self._convert_mlp_param(name, parameter, layer_number)
         converted_params = []
         num_local_experts = parameter.shape[0]
 

--- a/awex/reader/nccl_reader.py
+++ b/awex/reader/nccl_reader.py
@@ -101,87 +101,18 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
             f"Start to initialize NCCL weights writer for rank {self.transfer_rank}"
         )
 
-        from awex.util.process_group import (
-            init_weights_update_group,
-            setup_batch_isend_irecv,
-        )
-
-        gpu_id = getattr(self.scheduler, "gpu_id", None) or getattr(
-            self.scheduler, "local_rank", None
-        )
-        if gpu_id is None:
-            gpu_id = int(os.environ.get("LOCAL_RANK", 0))
-        device_type = device_util.get_device_type()
-        device_count = device_util.device_count() or 1
-        if device_type == "cuda":
-            prev_device = torch.cuda.current_device()
-            logger.info(
-                f"[NCCLWeightsReader] Set device to {gpu_id} for rank {self.transfer_rank}, "
-                f"device env is {os.environ.get('DEVICE')}, "
-                f"previous device is {prev_device}, "
-                f"device_count is {device_count}, "
-                f"CUDA_VISIBLE_DEVICES env is {os.environ.get('CUDA_VISIBLE_DEVICES')}"
-            )
-            torch.cuda.set_device(gpu_id)
-            barrier_device = torch.cuda.current_device()
-            backend = "nccl"
-            ready_tensor = torch.tensor(1).cuda()
-        else:
-            logger.info(
-                f"[NCCLWeightsReader] Set device to {gpu_id} for rank {self.transfer_rank}, "
-                f"device env is {os.environ.get('DEVICE')}, "
-                f"previous device is {device_util.current_device()}, "
-                f"device_count is {device_count}, "
-                f"{'/'.join(device_util.visible_devices_env_names())} env is {device_util.visible_devices_env_value() or '(unset)'}"
-            )
-            device_util.set_device(gpu_id)
-            barrier_device = device_util.current_device()
-            backend = self.comm_backend
-            ready_tensor = torch.tensor(1, device=device_util.get_torch_device())
-        world_size = (
+        self.master_address = master_address
+        self.master_port = master_port
+        self.world_size = (
             self.infer_world_size
             if self.enable_colocate_mode
             else self.transfer_world_size
         )
-        self.weights_update_group = init_weights_update_group(
-            master_address=master_address,
-            master_port=master_port,
-            rank=self.transfer_rank,
-            world_size=world_size,
-            group_name="weights_exchange",
-            backend=backend,
-            role="inference",
-        )
-        logger.info(
-            f"Initialized NCCL weights reader for rank {self.transfer_rank}, engine rank {self.engine_rank}"
-        )
-        # Add a barrier to ensure all processes are ready
-        dist.barrier(group=self.weights_update_group, device_ids=[barrier_device])
-        logger.info(f"Barrier passed for weights reader with rank {self.transfer_rank}")
-        if self.transfer_rank == 0:
-            logger.info(
-                f"Start to test NCCL ready for rank {self.transfer_rank}, world size {self.transfer_world_size}"
-            )
-            dist.recv(
-                ready_tensor,
-                src=world_size - 1,
-                group=self.weights_update_group,
-            )
-            logger.info(
-                f"NCCL ready: recv tensor from rank 0 for rank {self.transfer_rank}"
-            )
-        if (
-            self.enable_colocate_mode
-            and self.transfer_rank == self.infer_world_size - 1
-        ):
-            dist.send(
-                ready_tensor,
-                dst=0,
-                group=self.weights_update_group,
-            )
-        setup_batch_isend_irecv(
-            self.weights_update_group, self.transfer_rank, world_size
-        )
+
+        self._set_device()
+        self._init_weights_exchange_process_group()
+        self._shake_hands_with_writer()
+
         self.send_ranks = list(self.transfer_plan.operations.keys())
         self.send_ranks_sample = (
             self.send_ranks[:8] + ["..."] + self.send_ranks[-8:]
@@ -200,6 +131,102 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
         logger.info(
             f"Created NCCL weights reader for rank {self.rank_info.global_rank}, engine rank {self.engine_rank}"
         )
+
+    def _shake_hands_with_writer(self):
+        from awex.util.process_group import (
+            setup_batch_isend_irecv,
+        )
+
+        if self.transfer_rank == 0:
+            logger.info(
+                f"Start to test NCCL ready for rank {self.transfer_rank}, world size {self.transfer_world_size}"
+            )
+            dist.recv(
+                self.ready_tensor,
+                src=self.world_size - 1,
+                group=self.weights_update_group,
+            )
+            logger.info(
+                f"NCCL ready: recv tensor from rank 0 for rank {self.transfer_rank}"
+            )
+        if (
+            self.enable_colocate_mode
+            and self.transfer_rank == self.infer_world_size - 1
+        ):
+            dist.send(
+                self.ready_tensor,
+                dst=0,
+                group=self.weights_update_group,
+            )
+        setup_batch_isend_irecv(
+            self.weights_update_group, self.transfer_rank, self.world_size
+        )
+
+    def _set_device(self):
+        gpu_id = getattr(self.scheduler, "gpu_id", None) or getattr(
+            self.scheduler, "local_rank", None
+        )
+        if gpu_id is None:
+            gpu_id = int(os.environ.get("LOCAL_RANK", 0))
+        device_type = device_util.get_device_type()
+        device_count = device_util.device_count() or 1
+        if device_type == "cuda":
+            prev_device = torch.cuda.current_device()
+            logger.info(
+                f"[NCCLWeightsReader] Set device to {gpu_id} for rank {self.transfer_rank}, "
+                f"device env is {os.environ.get('DEVICE')}, "
+                f"previous device is {prev_device}, "
+                f"device_count is {device_count}, "
+                f"CUDA_VISIBLE_DEVICES env is {os.environ.get('CUDA_VISIBLE_DEVICES')}"
+            )
+            torch.cuda.set_device(gpu_id)
+            self.barrier_device = torch.cuda.current_device()
+            self.backend = "nccl"
+            self.ready_tensor = torch.tensor(1).cuda()
+        else:
+            logger.info(
+                f"[NCCLWeightsReader] Set device to {gpu_id} for rank {self.transfer_rank}, "
+                f"device env is {os.environ.get('DEVICE')}, "
+                f"previous device is {device_util.current_device()}, "
+                f"device_count is {device_count}, "
+                f"{'/'.join(device_util.visible_devices_env_names())} env is {device_util.visible_devices_env_value() or '(unset)'}"
+            )
+            device_util.set_device(gpu_id)
+            self.barrier_device = device_util.current_device()
+            self.backend = self.comm_backend
+            self.ready_tensor = torch.tensor(1, device=device_util.get_torch_device())
+
+    def _init_weights_exchange_process_group(self):
+        if self.already_initialized:
+            return
+        from awex.util.process_group import (
+            init_weights_update_group,
+        )
+
+        self.weights_update_group = init_weights_update_group(
+            master_address=self.master_address,
+            master_port=self.master_port,
+            rank=self.transfer_rank,
+            world_size=self.world_size,
+            group_name="weights_exchange",
+            backend=self.backend,
+            role="inference",
+        )
+        logger.info(
+            f"Initialized NCCL weights reader for rank {self.transfer_rank}, engine rank {self.engine_rank}"
+        )
+        # Add a barrier to ensure all processes are ready
+        dist.barrier(group=self.weights_update_group, device_ids=[self.barrier_device])
+        logger.info(f"Barrier passed for weights reader with rank {self.transfer_rank}")
+        self.already_initialized = True
+
+    def _destroy_weights_exchange_process_group(self):
+        # reduce the impact of process group to avoid oom in infer
+        if self.destroy_pg_after_update and self.backend == "hccl":
+            self.already_initialized = False
+            torch.distributed.destroy_process_group(self.weights_update_group)
+            torch.npu.synchronize()
+            torch.npu.empty_cache()
 
     def _init_reader_in_colocate_mode(self):
         self.meta_server_client.add_object_to_set(
@@ -299,6 +326,16 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
         )
         logger.info(f"Open fds after deserialization: {count_open_fds()}")
 
+    @staticmethod
+    def _sync_non_contiguous_tensor_pairs(non_contiguous_tensor_pairs):
+        if not non_contiguous_tensor_pairs:
+            return
+        with torch.no_grad():
+            for original_tensor, recv_tensor in non_contiguous_tensor_pairs:
+                original_tensor.copy_(recv_tensor)
+            non_contiguous_tensor_pairs.clear()
+            del non_contiguous_tensor_pairs
+
     def _update_weights(self, step_id, **kwargs):
         """
         Asynchronously receive weights from training ranks using torch.distributed.irecv.
@@ -318,12 +355,16 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
             f"{len(self.transfer_plan.operations)} ranks({self.send_ranks_sample}) "
             f"for rank {self.rank_coordinate}."
         )
+        self._init_weights_exchange_process_group()
         start_time = time.time()
 
         # Build receive ops once for logging, then execute them via
         # batch_send_recv to keep scheduling consistent with the writer.
-        p2p_op_list = nccl_build_recv_ops(
-            self.parameters, self.transfer_plan, self.weights_update_group
+        p2p_op_list, non_contiguous_tensor_pairs, recv_traj_list = nccl_build_recv_ops(
+            self.parameters,
+            self.transfer_plan,
+            self.weights_update_group,
+            self.use_batch_send_recv,
         )
         logger.info(
             f"Reader: Built {len(p2p_op_list)} recv operations from "
@@ -333,12 +374,14 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
         logger.info(
             f"Reader: Executing {len(p2p_op_list)} recv ops via batch_send_recv"
         )
-        batch_send_recv(
-            send_ops=[], recv_ops=p2p_op_list, blocking=True, use_group=True
-        )
-        # Some parameters are represented by contiguous recv buffers in
-        # WorkerWeightsReader; sync them back to model views after comm.
-        self._sync_noncontiguous_parameter_views()
+        if self.use_batch_send_recv:
+            batch_send_recv(
+                send_ops=[], recv_ops=p2p_op_list, blocking=True, use_group=True
+            )
+        else:
+            self._send_recv_one_by_one(p2p_op_list, recv_traj_list)
+
+        self._sync_non_contiguous_tensor_pairs(non_contiguous_tensor_pairs)
         device_util.synchronize(device_id=device_util.current_device())
         duration = time.time() - start_time
         logger.info(
@@ -358,6 +401,43 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
         logger.info(
             f"Barrier passed for reader step {step_id} with rank {self.transfer_rank}"
         )
+        if p2p_op_list is not None:
+            p2p_op_list.clear()
+            del p2p_op_list
+        self._destroy_weights_exchange_process_group()
+        gc.collect()
+
+    def _send_recv_one_by_one(self, p2p_op_list, recv_traj_list):
+        # it's useful for debug or insufficient memory if infer with closed sleep mode
+        # it's useful for the hardware diff scene which using batch_send_recv will be error,such as 910B2 and 910B1
+        for (param_name, send_rank), op_dist in zip(recv_traj_list, p2p_op_list):
+            logger.debug(
+                f"Reader {self.transfer_rank} start to receive from {send_rank} for {param_name}"
+            )
+            non_contiguous_tensor_pair = None
+            if not op_dist.tensor.is_contiguous():
+                original_tensor = op_dist.tensor
+                op_dist.tensor = original_tensor.contiguous()
+                non_contiguous_tensor_pair = (original_tensor, op_dist.tensor)
+
+            op_task = op_dist.op(
+                op_dist.tensor,
+                group=op_dist.group,
+                tag=op_dist.tag,
+                group_src=op_dist.group_peer,
+            )
+            op_task.wait()
+            if not op_task.is_completed():
+                device_util.synchronize(device_id=device_util.current_device())
+                assert op_task.is_completed()
+            if non_contiguous_tensor_pair is not None:
+                with torch.no_grad():
+                    non_contiguous_tensor_pair[0].copy_(non_contiguous_tensor_pair[1])
+                del non_contiguous_tensor_pair
+                del op_dist.tensor
+            logger.debug(
+                f"Reader {self.transfer_rank} end to receive from {send_rank} for {param_name}"
+            )
 
     def _update_weights_in_colocate_mode(self, step_id, **kwargs):
         assert self.enable_colocate_mode, "Colocate mode is not enabled"
@@ -380,8 +460,6 @@ class NCCLWorkerWeightsReader(WorkerWeightsReader):
             self.parameters,
             step_id=step_id,
         )
-        # Keep model parameter views consistent when recv used contiguous buffers.
-        self._sync_noncontiguous_parameter_views()
         print_current_gpu_status(
             f"after weights update using NCCL for rank {self.rank_coordinate}"
         )

--- a/awex/reader/weights_reader.py
+++ b/awex/reader/weights_reader.py
@@ -712,43 +712,26 @@ class WorkerWeightsReader:
         # are non-contiguous views. NCCL recv requires contiguous tensors, so we
         # receive into contiguous buffers and copy back to these views after recv.
         self._noncontiguous_parameter_views: Dict[str, torch.Tensor] = {}
+
+        self.already_initialized = False
+        self.destroy_pg_after_update = (
+            os.getenv("AWEX_DESTROY_PG_AFTER_UPDATE", "0") == "1"
+        )
+        self.use_batch_send_recv = os.getenv("AWEX_USE_BATCH_SEND_RECV", "1") == "1"
+        self.parameters = {}
         logger.info(f"Env varabbles for weights reader: {stripped_env_vars()}")
         logger.info(
             f"Created weights reader for rank {self.rank_info.global_rank}, engine rank {self.engine_rank}"
         )
 
     def initialize(self):
-        self.parameters = {}
-        self._noncontiguous_parameter_views = {}
-        non_contiguous = []
-        non_contiguous_bytes = 0
-        for name, param in self.model.named_parameters():
-            for hf_name, hf_param in self.weight_converter.convert_param(name, param):
-                if hf_param.is_contiguous():
-                    self.parameters[hf_name] = hf_param
-                    continue
-                recv_buffer = torch.empty_like(hf_param).contiguous()
-                recv_buffer.copy_(hf_param)
-                self.parameters[hf_name] = recv_buffer
-                self._noncontiguous_parameter_views[hf_name] = hf_param
-                non_contiguous.append((hf_name, tuple(hf_param.shape)))
-                non_contiguous_bytes += hf_param.numel() * hf_param.element_size()
-        if non_contiguous:
-            sample = ", ".join(f"{name}:{shape}" for name, shape in non_contiguous[:8])
-            logger.info(
-                "Reader rank %s uses contiguous recv buffers for %s non-contiguous params "
-                "(~%.2f MiB, showing up to 8): %s",
-                self.rank_info.global_rank,
-                len(non_contiguous),
-                non_contiguous_bytes / (1024 * 1024),
-                sample,
-            )
-            if len(non_contiguous) > 8:
-                logger.debug(
-                    "Reader rank %s remaining buffered params: %s",
-                    self.rank_info.global_rank,
-                    [name for name, _ in non_contiguous[8:]],
-                )
+        self.parameters = {
+            hf_name: hf_param
+            for name, param in self.model.named_parameters()
+            for hf_name, hf_param in self.weight_converter.convert_param(name, param)
+        }
+
+        # todo check this param
         if (
             getattr(self.hf_config, "tie_word_embeddings", False)
             and self.rank_info.pp_rank == self.rank_info.pp_size - 1
@@ -762,12 +745,6 @@ class WorkerWeightsReader:
             logger.info(
                 "WeightsReader: added lm_head.weight alias for tied embeddings."
             )
-
-    def _sync_noncontiguous_parameter_views(self):
-        if not self._noncontiguous_parameter_views:
-            return
-        for name, target_view in self._noncontiguous_parameter_views.items():
-            target_view.copy_(self.parameters[name])
 
     def pre_update_weights(self, step_id, **kwargs):
         pass
@@ -812,7 +789,6 @@ class WorkerWeightsReader:
                 )
             )
         self.read_tensors(step_id, tensor_pairs, **kwargs)
-        self._sync_noncontiguous_parameter_views()
         self.finish_step(step_id)
         logger.info(
             f"Finished updating weights for step {step_id} for rank {self.engine_rank}-{self.rank_info.global_rank}"

--- a/awex/transfer/nccl_comm.py
+++ b/awex/transfer/nccl_comm.py
@@ -375,12 +375,19 @@ def execute_p2p_op_list(p2p_op_list, stage: str, weights_update_group):
 
 
 @torch.no_grad()
-def nccl_build_send_ops(parameters, transfer_plan, weights_update_group, copy_rank):
+def nccl_build_send_ops(
+    parameters,
+    transfer_plan,
+    weights_update_group,
+    copy_rank,
+    use_batch_send_recv: bool = True,
+):
     mem_debug = os.environ.get("AWEX_MEM_DEBUG", "0") == "1"
     send_progress = dict.fromkeys(transfer_plan.operations.keys(), 0)
     unfinished_ranks = set(transfer_plan.operations.keys())
     p2p_op_list = []
     copy_op_list = []
+    send_traj_list = []
     train_slice_context = {}
     while len(unfinished_ranks) > 0:
         finished_ranks = set()
@@ -397,6 +404,8 @@ def nccl_build_send_ops(parameters, transfer_plan, weights_update_group, copy_ra
                 if recv_rank == copy_rank:
                     copy_op_list.append(tensor_sliced)
                 else:
+                    if not use_batch_send_recv:
+                        send_traj_list.append((op.send_shard_meta.name, recv_rank))
                     p2p_op_list.append(
                         dist.P2POp(
                             dist.isend,
@@ -432,13 +441,18 @@ def nccl_build_send_ops(parameters, transfer_plan, weights_update_group, copy_ra
             p2p_bytes,
             len(unique_ptrs),
         )
-    return p2p_op_list, copy_op_list
+    return p2p_op_list, copy_op_list, send_traj_list
 
 
 def nccl_build_recv_ops(
-    parameters: Dict[str, torch.Tensor], transfer_plan, weights_update_group
+    parameters: Dict[str, torch.Tensor],
+    transfer_plan,
+    weights_update_group,
+    use_batch_send_recv: bool = True,
 ):
     p2p_op_list = []
+    non_contiguous_tensor_pairs = []
+    recv_traj_list = []
     recv_progress = dict.fromkeys(transfer_plan.operations.keys(), 0)
     unfinished_ranks = set(transfer_plan.operations.keys())
     while len(unfinished_ranks) > 0:
@@ -451,6 +465,12 @@ def nccl_build_recv_ops(
                 op = operations[progress]
                 recv_tensor = parameters[op.recv_shard_meta.name]
                 tensor_sliced = slice_tensor(recv_tensor, op, False)
+                if not tensor_sliced.is_contiguous() and use_batch_send_recv:
+                    original_tensor = tensor_sliced
+                    tensor_sliced = tensor_sliced.contiguous()
+                    non_contiguous_tensor_pairs.append((original_tensor, tensor_sliced))
+                if not use_batch_send_recv:
+                    recv_traj_list.append((op.recv_shard_meta.name, send_rank))
                 p2p_op_list.append(
                     dist.P2POp(
                         dist.irecv,
@@ -464,7 +484,7 @@ def nccl_build_recv_ops(
                 finished_ranks.add(send_rank)
         for rank in finished_ranks:
             unfinished_ranks.remove(rank)
-    return p2p_op_list
+    return p2p_op_list, non_contiguous_tensor_pairs, recv_traj_list
 
 
 def _interleave_p2p_ops_by_peer(ops: Sequence[dist.P2POp]) -> List[dist.P2POp]:

--- a/awex/transfer/nccl_stream_batch.py
+++ b/awex/transfer/nccl_stream_batch.py
@@ -20,6 +20,7 @@ import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 
+import torch
 import torch.distributed as dist
 
 from awex import logging
@@ -86,6 +87,7 @@ class NcclColocateStreamBatchTransport:
         all_recv_p2p_ops = {}  # peer_rank -> List[(plan_op, p2p_op)]
         tensors_to_copy = []
         train_slice_context = {}
+        non_contiguous_tensor_pairs = []
 
         # Process send operations
         for peer_rank, ops in send_ops.items():
@@ -130,6 +132,10 @@ class NcclColocateStreamBatchTransport:
             for op in ops:
                 recv_tensor = recv_parameters[op.recv_shard_meta.name]
                 tensor_sliced = slice_tensor(recv_tensor, op, False)
+                if not tensor_sliced.is_contiguous():
+                    original_tensor = tensor_sliced
+                    tensor_sliced = tensor_sliced.contiguous()
+                    non_contiguous_tensor_pairs.append((original_tensor, tensor_sliced))
                 p2p_op = dist.P2POp(
                     dist.irecv if async_op else dist.recv,
                     tensor_sliced,
@@ -169,7 +175,12 @@ class NcclColocateStreamBatchTransport:
             rank_coordinate,
             step_id,
         )
-
+        if non_contiguous_tensor_pairs:
+            with torch.no_grad():
+                for original_tensor, recv_tensor in non_contiguous_tensor_pairs:
+                    original_tensor.copy_(recv_tensor)
+                non_contiguous_tensor_pairs.clear()
+                del non_contiguous_tensor_pairs
         device_util.synchronize()
         future.set_result(True)
         duration = time.time() - start_time

--- a/awex/transfer/transfer_plan.py
+++ b/awex/transfer/transfer_plan.py
@@ -702,6 +702,9 @@ def slice_tensor(
     """
     slices = op.train_slices if is_train else op.inf_slices
     sliced_tensor = tensor[slices]
+    if not is_train:
+        # sliced_tensor for infer may not be contiguous
+        return sliced_tensor
     if not sliced_tensor.is_contiguous():
         param_name = op.send_shard_meta.name
         source_offset = op.send_offset if is_train else op.recv_offset

--- a/awex/util/process_group.py
+++ b/awex/util/process_group.py
@@ -218,12 +218,24 @@ def init_weights_update_group(
     )
 
     try:
+        options = None
+        if backend == "hccl":
+            import torch_npu
+
+            options = torch_npu._C._distributed_c10d.ProcessGroupHCCL.Options()
+            # first,using specified buffer size instead of global buffer size while large size has higher throughput,
+            # because the memory used is 2 * buffer_size MB.
+            # second,rollout and actor must have a same buffer size for group init.
+            options.hccl_config = {
+                "hccl_buffer_size": int(os.getenv("AWEX_P2P_HCCL_BUFFER_SIZE", "200"))
+            }
         group = init_custom_process_group(
             backend=backend,
             init_method=f"tcp://{master_address}:{master_port}",
             world_size=world_size,
             rank=rank,
             group_name=group_name,
+            pg_options=options,
         )
         logger.info(f"Initialized custom process group: {group}")
         return group

--- a/awex/writer/nccl_writer.py
+++ b/awex/writer/nccl_writer.py
@@ -109,26 +109,20 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
         master_info = self.meta_server_client.get_object(
             "master_info", timeout=self.timeout
         )
-        master_address, master_port = master_info
+        self.master_address, self.master_port = master_info
         logger.info(
             f"Get master info from meta server for rank {self.transfer_rank}: {master_info}"
         )
         self._set_device()
-        self.weights_update_group = init_weights_update_group(
-            master_address,
-            master_port,
-            self.transfer_rank,
-            self.transfer_world_size,
-            "weights_exchange",
-            backend=self.comm_backend,
-            role="train",
+        self._init_weights_exchange_process_group()
+        self._shake_hands_with_reader()
+
+        logger.info(
+            f"Finished initializing NCCL weights writer for rank {self.transfer_rank}"
         )
-        logger.info(f"Initialized NCCL weights writer for rank {self.transfer_rank}")
-        # Add a barrier to ensure all processes are ready
-        dist.barrier(
-            group=self.weights_update_group, device_ids=[device_util.current_device()]
-        )
-        logger.info(f"Barrier passed for weights writer with rank {self.transfer_rank}")
+
+    def _shake_hands_with_reader(self):
+
         if self.transfer_rank == self.transfer_world_size - 1:
             logger.info(
                 f"Start to test NCCL ready for rank {self.transfer_rank}, world size {self.transfer_world_size}"
@@ -144,9 +138,6 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
         setup_batch_isend_irecv(
             self.weights_update_group, self.transfer_rank, self.transfer_world_size
         )
-        logger.info(
-            f"Finished initializing NCCL weights writer for rank {self.transfer_rank}"
-        )
 
     def _set_device(self):
         device = device_util.current_device()
@@ -158,6 +149,35 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
             f"{'/'.join(device_util.visible_devices_env_names())} env is {device_util.visible_devices_env_value() or '(unset)'}"
         )
         device_util.set_device(gpu_id)
+
+    def _init_weights_exchange_process_group(self):
+        if self.already_initialized:
+            return
+
+        self.weights_update_group = init_weights_update_group(
+            master_address=self.master_address,
+            master_port=self.master_port,
+            rank=self.transfer_rank,
+            world_size=self.transfer_world_size,
+            group_name="weights_exchange",
+            backend=self.comm_backend,
+            role="train",
+        )
+        logger.info(f"Initialized NCCL weights writer for rank {self.transfer_rank}")
+        # Add a barrier to ensure all processes are ready
+        dist.barrier(
+            group=self.weights_update_group, device_ids=[device_util.current_device()]
+        )
+        logger.info(f"Barrier passed for weights writer with rank {self.transfer_rank}")
+        self.already_initialized = True
+
+    def _destroy_weights_exchange_process_group(self):
+        # reduce the impact of process group to avoid oom in infer
+        if self.destroy_pg_after_update and self.backend == "hccl":
+            self.already_initialized = False
+            torch.distributed.destroy_process_group(self.weights_update_group)
+            torch.npu.synchronize()
+            torch.npu.empty_cache()
 
     def _init_writer_in_colocate_mode(self):
         self.ipc_backend = self.asystem_train_config.get(
@@ -196,6 +216,7 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
             f"ranks({self.recv_ranks_sample}) from rank {rank_coordinate} "
             f"with {self.num_to_sends} sends"
         )
+        self._init_weights_exchange_process_group()
         start_time = time.time()
         parameters = None
         p2p_op_list = None
@@ -208,8 +229,12 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
             logger.info("Writer: Converting parameters completed, building send ops")
             if self.enable_mem_debug:
                 print_current_gpu_status(f"writer-{self.transfer_rank} after convert")
-            p2p_op_list, _ = nccl_build_send_ops(
-                parameters, self.transfer_plan, self.weights_update_group, -1
+            p2p_op_list, _, send_traj_list = nccl_build_send_ops(
+                parameters,
+                self.transfer_plan,
+                self.weights_update_group,
+                -1,
+                self.use_batch_send_recv,
             )
             logger.info(
                 f"Writer: Built {len(p2p_op_list)} send operations to "
@@ -236,9 +261,12 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
             logger.info(
                 f"Writer: Executing {len(p2p_op_list)} send ops via batch_send_recv"
             )
-            batch_send_recv(
-                send_ops=p2p_op_list, recv_ops=[], blocking=True, use_group=True
-            )
+            if self.use_batch_send_recv:
+                batch_send_recv(
+                    send_ops=p2p_op_list, recv_ops=[], blocking=True, use_group=True
+                )
+            else:
+                self._send_recv_one_by_one(p2p_op_list, send_traj_list)
             device_util.synchronize(device_id=device_util.current_device())
             if self.enable_mem_debug:
                 print_current_gpu_status(f"writer-{self.transfer_rank} after send")
@@ -267,6 +295,7 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
                 p2p_op_list.clear()
             if parameters is not None:
                 parameters.clear()
+            self._destroy_weights_exchange_process_group()
             gc.collect()
             if self.enable_mem_debug:
                 if device_util.get_device_type() == "cuda":
@@ -274,6 +303,27 @@ class NCCLWeightsWriter(WeightsExchangeShardingWriter):
                 elif device_util.get_device_type() == "npu" and hasattr(torch, "npu"):
                     torch.npu.empty_cache()
                 print_current_gpu_status(f"writer-{self.transfer_rank} after cleanup")
+
+    def _send_recv_one_by_one(self, p2p_op_list, send_traj_list):
+        # it's useful for debug or insufficient memory if infer with closed sleep mode
+        # it's useful for the hardware diff scene which using batch_send_recv will be error,such as 910B2 and 910B1
+        for (param_name, send_rank), op_dist in zip(send_traj_list, p2p_op_list):
+            logger.debug(
+                f"Writer {self.transfer_rank} start to send to {send_rank} for {param_name}"
+            )
+            op_task = op_dist.op(
+                op_dist.tensor,
+                group=op_dist.group,
+                tag=op_dist.tag,
+                group_dst=op_dist.group_peer,
+            )
+            op_task.wait()
+            if not op_task.is_completed():
+                device_util.synchronize(device_id=device_util.current_device())
+                assert op_task.is_completed()
+            logger.debug(
+                f"Writer {self.transfer_rank} end to send from {send_rank} for {param_name}"
+            )
 
     @torch.no_grad()
     def _prepare_params_for_colocate(self):

--- a/awex/writer/weights_writer.py
+++ b/awex/writer/weights_writer.py
@@ -131,6 +131,11 @@ class WeightsExchangeShardingWriter(WeightExchangeWriter):
         self.num_infer_engines = None
         self.engine_name = train_engine.engine_name
         self.enable_mem_debug = os.environ.get("AWEX_MEM_DEBUG", "0") == "1"
+        self.already_initialized = False
+        self.destroy_pg_after_update = (
+            os.getenv("AWEX_DESTROY_PG_AFTER_UPDATE", "0") == "1"
+        )
+        self.use_batch_send_recv = os.getenv("AWEX_USE_BATCH_SEND_RECV", "1") == "1"
 
     def initialize(self, **kwargs):
         pass

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -4,10 +4,11 @@ import argparse
 import re
 from pathlib import Path
 
-
 VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 VERSION_LINE_PATTERN = re.compile(r'(?m)^__version__ = "[^"]+"$')
-DEFAULT_TARGET = Path(__file__).resolve().parent.parent / "awex" / "reader" / "__init__.py"
+DEFAULT_TARGET = (
+    Path(__file__).resolve().parent.parent / "awex" / "reader" / "__init__.py"
+)
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## What does this PR do?
support infer slice tensor at dim > 0 which could make p2p tensor not continuous in NCCL or HCCL and optimize memory using

<!-- Describe the details of this PR. -->
1、support infer tensor slice at dim >0 such as attention.dense.weight when infer's tp < train's tp which could make p2p tensor not continuous in NCCL or HCCL. another scene is the experts in VLLM-ascend has been transposed but shared_experts not.

2、optimize memory by supporting p2p send receive one by one, it's useful for debug or insufficient memory if infer with closed sleep mode and it's also useful for the hardware diff scene which using batch_send_recv will be error,such as 910B2 and 910B1. p2p send receive one by one comparing with batch send receive, can increase time consumption less than 10% but decrease peak memory 25% for qwen3-30B

3、optimize memory by using local part process group and destroy weight exchange process group in NPU HCCL, because the HCCL_BUFFERSIZE actually occupies twice the memory, and it also requires HCCL_BUFFERSIZE  keep consistency at infer and train. Using local part process group can optimize this portion of the memory.

## Related issues
No

## Does this PR introduce any user-facing change?
No


- [ ] Does this PR introduce any public API change? NO
- [ ] Does this PR introduce any binary protocol compatibility change? NO
