### PR TITLE
fix:improve validate

### DIFF
--- a/awex/config.py
+++ b/awex/config.py
@@ -189,7 +189,7 @@ class InferenceConfig:
         return self
 
     @staticmethod
-    def from_dict(config_dict: Dict[str, Any]) -> "InferenceConfig":
+    def from_dict(config_dict: Dict[str, Any], validate: bool = True) -> "InferenceConfig":
         # remove all keys that are not fields of InferenceConfig
         config_dict = {
             k: v
@@ -197,7 +197,8 @@ class InferenceConfig:
             if k in InferenceConfig.__dataclass_fields__
         }
         cfg = InferenceConfig(**config_dict)
-        cfg.validate()
+        if validate:
+            cfg.validate()
         return cfg
 
     @staticmethod

--- a/awex/util/common.py
+++ b/awex/util/common.py
@@ -246,7 +246,8 @@ def check_train_infer_params_meta(
                 logger.error(error_msg)
         infer_tp_size = len(infer_param_meta.replicas[0].shards)
         train_tp_size = len(train_param_meta.replicas[0].shards)
-        if infer_tp_size < train_tp_size or infer_tp_size % train_tp_size != 0:
+        max_tp, min_tp = max(infer_tp_size, train_tp_size), min(infer_tp_size, train_tp_size)
+        if max_tp % min_tp != 0:
             error_msg = (
                 f"Inference for parameter {param_name} has wrong tp_size: "
                 f"infer {infer_tp_size} train {train_tp_size}"

--- a/awex/vllm_plugin.py
+++ b/awex/vllm_plugin.py
@@ -308,7 +308,7 @@ def _patch_awex_worker() -> None:
             )
         base_config = self._awex_infer_engine_config
         if infer_engine_config is not None:
-            merged = InferenceConfig.from_dict(base_config.__dict__)
+            merged = InferenceConfig.from_dict(base_config.__dict__, False)
             for field in InferenceConfig.__dataclass_fields__:
                 value = getattr(infer_engine_config, field, None)
                 if value is not None:


### PR DESCRIPTION
## What does this PR do?

1、在vllm_plugin中有对InferenceConfig.from_dict的调用，此时meta_server_addr必然取不到，在vllm dp>1时会触发error:meta_server_addr must be set when num_engines > 1

2、目前已支持infer tp < train tp，因此删除check_train_infer_params_meta里的约束，使得enable_debug_mode为false时也能正常执行

## Does this PR introduce any user-facing change?
NO

- [ ] Does this PR introduce any public API change?  NO
- [ ] Does this PR introduce any binary protocol compatibility change?  NO
