### PR TITLE
feat: support dense Qwen3 weight conversion

### DIFF
--- a/awex/meta/infer_meta_resolver.py
+++ b/awex/meta/infer_meta_resolver.py
@@ -223,7 +223,7 @@ class InferParamMetaResolver(ParamMetaResolver):
                     params.append((hf_name, hf_param))
             else:
                 params.append((name, param))
-        if convert_params and engine_name == "vllm":
+        if convert_params:
             hf_config = getattr(model, "config", None) or getattr(
                 model_context, "hf_config", None
             )
@@ -242,10 +242,16 @@ class InferParamMetaResolver(ParamMetaResolver):
                             embed_tensor = p
                             break
                     if embed_tensor is not None:
-                        # vLLM ties output weights to embeddings, but does not expose lm_head.
+                        # Both engines tie the output weights to the embedding
+                        # and expose no lm_head, while the training side still
+                        # publishes it. The reader adds the same alias, so the
+                        # metadata has to match or the transfer plan reports a
+                        # missing key.
                         params.append(("lm_head.weight", embed_tensor))
                         logger.info(
-                            "Infer meta: added lm_head.weight alias for tied embeddings in vLLM"
+                            "Infer meta: added lm_head.weight alias for tied "
+                            "embeddings on %s",
+                            engine_name,
                         )
         if os.environ.get("AWEX_DEBUG_INFER_META", "0") == "1":
             names = [n for n, _ in params]

--- a/awex/models/qwen3.py
+++ b/awex/models/qwen3.py
@@ -1,0 +1,37 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Registration for dense Qwen3 (``Qwen3ForCausalLM``).
+
+Dense and MoE Qwen3 share the layout both converters target: canonical
+``self_attn.{q,k,v,o}_proj`` with per-head ``self_attn.{q,k}_norm``, GQA head
+grouping in the fused Megatron ``linear_qkv``, and gate/up projections that
+sglang serves fused while the train side reports them split. The dense model
+simply has no expert parameters, so the shared converters need no change; only
+the architecture name has to be registered.
+"""
+
+from awex.models.qwen3_moe import (
+    SGlangToHFWeightConverterQwen3Moe,
+    _build_mcore_converter_qwen3_moe,
+)
+
+CONFIG = {
+    "model_name": "Qwen3ForCausalLM",
+    "mcore_converter": _build_mcore_converter_qwen3_moe,
+    "sglang_converter": SGlangToHFWeightConverterQwen3Moe,
+}

--- a/awex/tests/test_infer_meta_tied_embeddings.py
+++ b/awex/tests/test_infer_meta_tied_embeddings.py
@@ -1,0 +1,94 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tied-embedding lm_head alias in the inference parameter metadata."""
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from awex.meta.infer_meta_resolver import InferParamMetaResolver
+
+
+class Qwen3ForCausalLM:
+    def __init__(self, config, params):
+        self.config = config
+        self._params = params
+
+    def named_parameters(self):
+        return iter(self._params)
+
+
+def _model(tie_word_embeddings=True):
+    config = SimpleNamespace(
+        tie_word_embeddings=tie_word_embeddings,
+        num_attention_heads=8,
+        num_key_value_heads=2,
+        head_dim=4,
+        hidden_size=16,
+        architectures=["Qwen3ForCausalLM"],
+    )
+    params = [("model.embed_tokens.weight", torch.randn(32, 16))]
+    return Qwen3ForCausalLM(config, params)
+
+
+def _resolve(engine_name, model):
+    identity = SimpleNamespace(convert_param=lambda name, param: [(name, param)])
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "awex.meta.infer_meta_resolver.get_rank_info_extractor",
+                return_value=lambda ctx, rank: SimpleNamespace(
+                    tp_rank=0, ep_rank=0, global_rank=0
+                ),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "awex.meta.infer_meta_resolver.get_infer_weights_converter",
+                return_value=identity,
+            )
+        )
+        meta = InferParamMetaResolver._get_model_param_info(
+            engine_name,
+            SimpleNamespace(tp_size=1, ep_size=1, device_backend="cuda"),
+            convert_params=True,
+            engine_rank=0,
+            model=model,
+            model_context={"pp_rank": 0, "pp_size": 1},
+        )
+    return {entry["name"] for entry in meta["params_meta"]}
+
+
+@pytest.mark.parametrize("engine_name", ["sglang", "vllm"])
+def test_tied_embeddings_get_an_lm_head_alias_on_every_engine(engine_name):
+    """The reader adds the same alias, so the metadata has to match it.
+
+    Without the alias the transfer plan reports lm_head.weight as missing,
+    because the training side publishes it while the inference side ties the
+    output weights to the embedding.
+    """
+    assert "lm_head.weight" in _resolve(engine_name, _model())
+
+
+@pytest.mark.parametrize("engine_name", ["sglang", "vllm"])
+def test_untied_embeddings_get_no_alias(engine_name):
+    names = _resolve(engine_name, _model(tie_word_embeddings=False))
+    assert "lm_head.weight" not in names

--- a/awex/tests/test_qwen3_dense_sglang_converter.py
+++ b/awex/tests/test_qwen3_dense_sglang_converter.py
@@ -1,0 +1,129 @@
+# Licensed to the Awex developers under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Name-contract tests for dense Qwen3 (``Qwen3ForCausalLM``)."""
+
+from types import SimpleNamespace
+
+import torch
+
+from awex.models.qwen3 import CONFIG
+from awex.models.qwen3_moe import SGlangToHFWeightConverterQwen3Moe
+from awex.models.registry import get_infer_weights_converter
+
+NUM_HEADS = 8
+NUM_KV_HEADS = 2
+HEAD_DIM = 4
+HIDDEN = 16
+INTERMEDIATE = 8
+
+
+def _model_config():
+    return SimpleNamespace(
+        num_attention_heads=NUM_HEADS,
+        num_key_value_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        hidden_size=HIDDEN,
+        architectures=["Qwen3ForCausalLM"],
+    )
+
+
+def _rank_info():
+    return SimpleNamespace(tp_rank=0, ep_rank=0)
+
+
+def _infer_engine_config():
+    return SimpleNamespace(tp_size=1, ep_size=1, device_backend="cuda")
+
+
+def _converter():
+    return SGlangToHFWeightConverterQwen3Moe(
+        _model_config(), _infer_engine_config(), _rank_info()
+    )
+
+
+def test_config_registers_the_dense_architecture():
+    assert CONFIG["model_name"] == "Qwen3ForCausalLM"
+
+
+def test_registry_resolves_the_shared_sglang_converter():
+    converter = get_infer_weights_converter(
+        "sglang",
+        "Qwen3ForCausalLM",
+        _model_config(),
+        _rank_info(),
+        _infer_engine_config(),
+    )
+    assert isinstance(converter, SGlangToHFWeightConverterQwen3Moe)
+
+
+def test_layer_names_match_the_train_side_contract():
+    converter = _converter()
+    qkv_rows = (NUM_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM
+    sglang_params = {
+        "model.layers.0.self_attn.qkv_proj.weight": torch.randn(qkv_rows, HIDDEN),
+        "model.layers.0.self_attn.o_proj.weight": torch.randn(HIDDEN, HIDDEN),
+        "model.layers.0.self_attn.q_norm.weight": torch.randn(HEAD_DIM),
+        "model.layers.0.self_attn.k_norm.weight": torch.randn(HEAD_DIM),
+        "model.layers.0.input_layernorm.weight": torch.randn(HIDDEN),
+        "model.layers.0.post_attention_layernorm.weight": torch.randn(HIDDEN),
+        # sglang serves the dense MLP through MergedColumnParallelLinear
+        "model.layers.0.mlp.gate_up_proj.weight": torch.randn(2 * INTERMEDIATE, HIDDEN),
+        "model.layers.0.mlp.down_proj.weight": torch.randn(HIDDEN, INTERMEDIATE),
+    }
+
+    produced = set()
+    for name, param in sglang_params.items():
+        for hf_name, _ in converter.convert_param(name, param):
+            produced.add(hf_name)
+
+    assert produced == {
+        "model.layers.0.self_attn.q_proj.weight",
+        "model.layers.0.self_attn.k_proj.weight",
+        "model.layers.0.self_attn.v_proj.weight",
+        "model.layers.0.self_attn.o_proj.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.layers.0.self_attn.k_norm.weight",
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.post_attention_layernorm.weight",
+        "model.layers.0.mlp.gate_proj.weight",
+        "model.layers.0.mlp.up_proj.weight",
+        "model.layers.0.mlp.down_proj.weight",
+    }
+
+
+def test_qkv_split_is_gqa_aware():
+    converter = _converter()
+    qkv_rows = (NUM_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM
+    fused = torch.arange(qkv_rows * HIDDEN, dtype=torch.float32).reshape(
+        qkv_rows, HIDDEN
+    )
+
+    shapes = {
+        name: param.shape
+        for name, param in converter.convert_param(
+            "model.layers.0.self_attn.qkv_proj.weight", fused
+        )
+    }
+
+    assert shapes["model.layers.0.self_attn.q_proj.weight"][0] == NUM_HEADS * HEAD_DIM
+    assert (
+        shapes["model.layers.0.self_attn.k_proj.weight"][0] == NUM_KV_HEADS * HEAD_DIM
+    )
+    assert (
+        shapes["model.layers.0.self_attn.v_proj.weight"][0] == NUM_KV_HEADS * HEAD_DIM
+    )


### PR DESCRIPTION
## What does this PR do?

`Qwen3ForCausalLM` is not registered in `awex/models`, so it falls back to the
default converters. Those follow the bailing-style attention naming, and
`SGlangToHFWeightConverter._convert_layer_norm_param` raises
`NotImplementedError` on `self_attn.q_norm.weight`. The failure happens while
the reader is building its parameter metadata, so the reader never publishes
`infer_conf` and the writer waits for it indefinitely: the run stalls rather
than reporting the unsupported name.

Dense and MoE Qwen3 share the layout the existing `qwen3_moe` converters
already target:

- canonical `self_attn.{q,k,v,o}_proj` with per-head `self_attn.{q,k}_norm`
- GQA head grouping in the fused Megatron `linear_qkv`
- gate/up projections that sglang serves fused through
  `MergedColumnParallelLinear` while the train side reports them split

The dense model only lacks the expert parameters, which those converters emit
nothing for, so registering the architecture against them is enough and the
base converters are untouched. This mirrors `ling_linear.py`, which reuses
`ling.py`'s converters for its own architectures.

Dense Qwen3 also ties its output weights, which surfaced a second gap. Three
places add the `lm_head.weight` alias for tied embeddings, and they disagree:

| | engine gate |
|---|---|
| `reader/weights_reader.py` | none |
| `meta/train_meta_resolver.py` | none |
| `meta/infer_meta_resolver.py` | `engine_name == "vllm"` |

The reader therefore adds the alias on sglang while the inference metadata does
not declare it, and the transfer plan reports `lm_head.weight` as missing. This
PR drops the engine gate so the third site matches the other two.

### Verification

- `awex/tests` passes in full, on top of four new cases for the dense
  registration and four for the tied-embedding alias.
- Negative check against current `main`: asking the registry for
  `Qwen3ForCausalLM` logs `Model Qwen3ForCausalLM not found, using default
  strategy`, returns the base `SGlangToHFWeightConverter`, and
  `self_attn.q_norm.weight` raises `NotImplementedError`. The new tests fail
  without this change and the tied-embedding case fails for `sglang` while
  passing for `vllm`.
- A 20-step colocated GRPO run on Qwen3-0.6B (sglang inference, Megatron
  training, AWEX weight transfer) completes cleanly: no `Unsupported layer norm
  parameter name`, no wait on `infer_conf`, no missing `lm_head.weight`, and the
  "using default strategy" fallback no longer appears.

Not covered by unit tests: the Megatron-side dense path. It is exercised by the
end-to-end run above but has no test of its own yet.

## Related issues

None.

## Does this PR introduce any user-facing change?

- [ ] Does this PR introduce any public API change?
- [ ] Does this PR introduce any binary protocol compatibility change?

No signatures change and no new configuration is required; `Qwen3ForCausalLM`
is picked up by the existing registry discovery.

Worth noting for review: for a tied-embedding model served by sglang, the
published inference metadata now contains an additional `lm_head.weight` entry.
That is not a new protocol field. The reader already materialises this alias
regardless of engine, so the change makes the declared metadata agree with what
is actually transferred; previously the two sides disagreed and the transfer
plan failed.